### PR TITLE
INT-1192: Ensure lowercase CVE lookups return results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "MandiantThreatIntel",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MandiantThreatIntel",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "main": "./integration.js",
   "private": true,
   "dependencies": {

--- a/src/vulnerabilities/searchVulnerabilities.js
+++ b/src/vulnerabilities/searchVulnerabilities.js
@@ -1,4 +1,4 @@
-const { map, get, size, flow } = require('lodash/fp');
+const { toUpper, map, get, size, flow } = require('lodash/fp');
 const { getLogger } = require('../logging');
 
 const { authenticatedRequest } = require('../request');
@@ -20,7 +20,7 @@ const searchVulnerabilities = async (entityChunk, options) =>
       method: 'POST',
       url: `${options.urlV4}/v4/vulnerability`,
       body: {
-        requests: [{ values: map(get('value'), entityChunk) }],
+        requests: [{ values: map(flow(get('value'), toUpper), entityChunk) }],
         rating_types: map('value', options.vulnerabilityRatingSources),
         has_cve: true
       },


### PR DESCRIPTION
Mandiant API requires that CVE's be in uppercase (i.e., CVE-2020-0796 vs cve-2020-0796).  This PR ensures we also uppercase CVE lookups.